### PR TITLE
fix: applies theme text color to headings and bold

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -36,6 +36,20 @@ body {
   color: var(--text);
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--text);
+}
+
+b,
+strong {
+  color: var(--text);
+}
+
 a {
   color: var(--link);
 }


### PR DESCRIPTION
Ensures all heading levels (h1-h6) and bold text elements (b, strong) consistently adopt the primary text color defined by the `--text` CSS variable. This improves visual consistency and adherence to the theme.
