### PR TITLE
fix: adds dark mode support for images

### DIFF
--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -81,7 +81,12 @@
                                 flex-wrap:wrap;
                             ">
                                 <a href="https://ufam.edu.br" target="_blank" rel="noopener">
-                                    <img src="https://edoc.ufam.edu.br/bitstream/123456789/4819/7/marca_ufam_vetor_positivo.png"
+                                    <img class="theme-image theme-image-light"
+                                        src="https://edoc.ufam.edu.br/bitstream/123456789/4819/7/marca_ufam_vetor_positivo.png"
+                                        alt="UFAM"
+                                        style="height:65px;">
+                                    <img class="theme-image theme-image-dark"
+                                        src="https://edoc.ufam.edu.br/bitstream/123456789/4819/5/marca_ufam_vetor_negativo.png"
                                         alt="UFAM"
                                         style="height:65px;">
                                 </a>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -54,6 +54,18 @@ a {
   color: var(--link);
 }
 
+.theme-image-dark {
+  display: none;
+}
+
+html[data-theme="dark"] .theme-image-light {
+  display: none;
+}
+
+html[data-theme="dark"] .theme-image-dark {
+  display: inline;
+}
+
 section {
     margin-top: 25px;
 }

--- a/cv/index.md
+++ b/cv/index.md
@@ -28,7 +28,8 @@ page_intro: Academic background, professional experience, publications, and tech
         </h3>
         <div class="logos">
             <a href="http://ufam.edu.br" target="_blank"> 
-                <img src="https://ppge.ufam.edu.br/images/ufam.png" height="55" alt="UFAM Website">
+                <img class="theme-image theme-image-light" src="https://edoc.ufam.edu.br/bitstream/123456789/4819/7/marca_ufam_vetor_positivo.png" height="55" alt="UFAM Website">
+                <img class="theme-image theme-image-dark" src="https://edoc.ufam.edu.br/bitstream/123456789/4819/5/marca_ufam_vetor_negativo.png" height="55" alt="UFAM Website">
             </a>
             <a href="http://icomp.ufam.edu.br" target="_blank"> 
                 <img src="https://icomp.ufam.edu.br/images/icomp.png" height="55" alt="IComp Website">
@@ -87,7 +88,8 @@ page_intro: Academic background, professional experience, publications, and tech
   </h3>
   <div class="logos">
     <a href="http://ufam.edu.br" target="_blank"> 
-      <img src="https://ppge.ufam.edu.br/images/ufam.png" height="55" alt="UFAM Website">
+        <img class="theme-image theme-image-light" src="https://edoc.ufam.edu.br/bitstream/123456789/4819/7/marca_ufam_vetor_positivo.png" height="55" alt="UFAM Website">
+        <img class="theme-image theme-image-dark" src="https://edoc.ufam.edu.br/bitstream/123456789/4819/5/marca_ufam_vetor_negativo.png" height="55" alt="UFAM Website">
     </a>
     <a href="http://icomp.ufam.edu.br" target="_blank"> 
       <img src="https://icomp.ufam.edu.br/images/icomp.png" height="55" alt="IComp Website">

--- a/projects/research/se4ai_icse_2026.html
+++ b/projects/research/se4ai_icse_2026.html
@@ -86,7 +86,7 @@
           <!-- Fill these with your real links -->
           <a class="btn" href="../assets/ICSE_2026_Doctoral_Symposium.pdf" target="_blank" rel="noopener">📄 Paper (PDF)</a>
           <a class="btn" href="../assets/Poster_ICSE_Doctoral_2026_Manzoni.pdf" target="_blank" rel="noopener">🖼️ Poster (PDF)</a>
-          <a class="btn" href="YOUR_LINK_TO_SLIDES_OR_APPENDIX" target="_blank" rel="noopener">📎 Appendix</a>
+          <a class="btn" href="YOUR_LINK_TO_SLIDES_OR_APPENDIX" target="_blank" rel="noopener">📎 Presentation (PDF)</a>
         </div>
 
         <h2>Full References</h2>
@@ -133,7 +133,7 @@
         <p>
           <strong>Felipe Sonntag Manzoni</strong><br/>
           Federal University of Amazonas (UFAM) — Manaus, Brazil<br/>
-          SiDi Innovation & Intelligence Center — AI R&amp;D department<br/>
+          Institute of Computing — ICOMP — Sphere Research Group<br/>
           Email: <a href="mailto:fsm2@icomp.ufam.edu.br">fsm2@icomp.ufam.edu.br</a>
         </p>
         <div style="
@@ -152,15 +152,21 @@
               flex-wrap:wrap;
           ">
             <a href="https://ufam.edu.br" target="_blank" rel="noopener">
-              <img src="https://edoc.ufam.edu.br/bitstream/123456789/4819/7/marca_ufam_vetor_positivo.png"
+              <img src="https://edoc.ufam.edu.br/bitstream/123456789/4819/5/marca_ufam_vetor_negativo.png"
                   alt="UFAM"
                   style="height:65px;">
             </a>
 
-            <a href="https://www.sidi.org.br" target="_blank" rel="noopener">
-              <img src="https://ebdicorp.com.br/wp-content/uploads/2026/01/SIDI-768x320.png"
-                  alt="SiDi"
+            <a href="https://" target="_blank" rel="noopener">
+              <img src="https://www.icomp.ufam.edu.br/images/icomp.png"
+                  alt="IComp"
                   style="height:65px;">
+            </a>
+
+            <a href="https://icomp.ufam.edu.br/" target="_blank" rel="noopener">
+              <img src="/assets/images/sphere_logo_nobg.png"
+                alt="SPHERE Research Group - PPGI-IComp"
+                style="height:85px;">
             </a>
           </div>
         </div>


### PR DESCRIPTION
Implements theme-sensitive display for images by toggling visibility based on the `data-theme` attribute. This ensures appropriate logo versions (light or dark) are shown across different themes.

Updates UFAM logos in project layouts and the CV to leverage this new theme-aware functionality.

Also, updates details in the 'se4ai_icse_2026' project page:
- Revises affiliation details and button text.
- Replaces the SiDi logo with IComp and SPHERE Research Group logos.
