### PR TITLE
Streamlines GitHub link display across layouts

### DIFF
--- a/_layouts/blog_post.html
+++ b/_layouts/blog_post.html
@@ -62,17 +62,11 @@
                 </div>
                 </div>
 
-                {% if site.github.is_project_page %}
                 <p class="view">
                 <a href="{{ site.github.repository_url }}">
                     View the Project on GitHub <small>{{ site.github.repository_nwo }}</small>
                 </a>
                 </p>
-                {% endif %}
-
-                {% if site.github.is_user_page %}
-                <p class="view"><a href="{{ site.github.owner_url }}">View My GitHub Profile</a></p>
-                {% endif %}
             </header>
 
             <section>
@@ -114,15 +108,6 @@
                             style="height:32px;">
                     </a>
                 </div>
-
-                {% if site.github.is_user_page %}
-                <p class="view">
-                    <a href="{{ site.github.owner_url }}">
-                        View My GitHub Profile
-                    </a>
-                </p>
-                {% endif %}
-
                 <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
             </footer>
         </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -79,17 +79,11 @@
                 </div>
                 </div>
 
-                {% if site.github.is_project_page %}
                 <p class="view">
                 <a href="{{ site.github.repository_url }}">
                     View the Project on GitHub <small>{{ site.github.repository_nwo }}</small>
                 </a>
                 </p>
-                {% endif %}
-
-                {% if site.github.is_user_page %}
-                <p class="view"><a href="{{ site.github.owner_url }}">View My GitHub Profile</a></p>
-                {% endif %}
             </header>
 
             <section>
@@ -111,15 +105,6 @@
                             style="height:32px;">
                     </a>
                 </div>
-
-                {% if site.github.is_user_page %}
-                <p class="view">
-                    <a href="{{ site.github.owner_url }}">
-                        View My GitHub Profile
-                    </a>
-                </p>
-                {% endif %}
-
                 <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
             </footer>
         </div>

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -142,6 +142,11 @@
                         View My GitHub Profile
                     </a>
                 </p>
+                <p class="view">
+                <a href="{{ site.github.repository_url }}">
+                    View the Project on GitHub <small>{{ site.github.repository_nwo }}</small>
+                </a>
+                </p>
                 <div style="margin-top:20px; display:flex; justify-content:left; align-items:center; gap: 5px;">
                     <span>How about a espresso patronum? </span>
                     <a href="https://ko-fi.com/manzoni" target="_blank" rel="noopener"
@@ -151,15 +156,6 @@
                             style="height:32px;">
                     </a>
                 </div>
-
-                {% if site.github.is_user_page %}
-                <p class="view">
-                    <a href="{{ site.github.owner_url }}">
-                        View My GitHub Profile
-                    </a>
-                </p>
-                {% endif %}
-
                 <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
             </footer>
         </div>


### PR DESCRIPTION
Removes conditional rendering for "View the Project" and "View My GitHub Profile" links from blog post and default layouts.

Unconditionally displays "View My GitHub Profile" and "View the Project on GitHub" links in the projects layout, simplifying the logic by removing `is_project_page` and `is_user_page` checks.
